### PR TITLE
Remove uneven gutters by changing large screen width to max-width

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -1,5 +1,5 @@
 body {
-    background: url(/images/background.jpg) no-repeat top center fixed; 
+    background: url(/images/background.jpg) no-repeat top center fixed;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;
@@ -19,9 +19,9 @@ body {
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=85)";
     filter: alpha(opacity=85);
     -moz-opacity: 0.85;
-    -khtml-opacity: 0.85; 
+    -khtml-opacity: 0.85;
 }
- 
+
 #date {
     color: blue;
 }
@@ -82,7 +82,7 @@ ol ol ol {
 
 @media (min-width: 53em) {
     #all {
-        width: 50em;
+        max-width: 50em;
         margin: 0 auto;
     }
 


### PR DESCRIPTION
Hi Mark - I was browsing your site to try and work out how the hell you'd managed to get your single-column layout working. In the process, I spotted the below, so I thought I'd suggest a fix.

This change replaces "width: 50em;" with "max-width: 50em;" in the css.
When width: 50em is set, if the website is just the right size, there
will be no right gutter. By setting max-width instead, it forces the
gutters to remain the same size at all widths.

Before:
![image](https://user-images.githubusercontent.com/4653812/70090304-cc88e480-1611-11ea-83d0-dd12cbbfd54d.png)

After:
![image](https://user-images.githubusercontent.com/4653812/70090336-dad70080-1611-11ea-9f0f-29e7eb32ebd3.png)
